### PR TITLE
fix long wait when start up reference-wallet

### DIFF
--- a/liquidity/liquidity.py
+++ b/liquidity/liquidity.py
@@ -233,6 +233,7 @@ class FaucetLiquidityProvider(LiquidityProvider):
         faucet.mint(
             account.authentication_key, quote.amount, quote.currency_pair.value.base
         )
+        trade.executed(-1)
 
 
 def liquidity_provider_default_factory() -> LiquidityProvider:


### PR DESCRIPTION
This is a temp fix of long wait when launching the reference-wallet with new env.
Should follow up a fix to set the right transaction version.